### PR TITLE
Minor update to 0.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ Other updates:
 Installation
 ------------
 
-Install Taichi THREE with `pip`:
+Install Taichi THREE Dev:
 
 ```bash
 # Python 3.6/3.7/3.8 (64-bit)
-pip install taichi_three
+pip install taichi taichi_glsl
+python setup.py build install
 ```
 
 This should also install its dependencies `taichi` and `taichi_glsl` as well.
@@ -70,13 +71,32 @@ model = t3.Model(t3.readobj('assets/monkey.obj', scale=0.6))
 scene.add_model(model)
 ```
 
+If you want to add texture, read the texture image and feed it into `model`:
+
+```py
+texture = ti.imread('assets/cloth.jpg')
+model = t3.Model(t3.readobj('assets/monkey.obj', scale=0.6), tex=texture)
+```
+
 NOTE: model creations should also be put as forward as possible too.
 
 ---
 
-Also don't forget to set the light (only parallel for now) direction:
+Then, create the camera(s), and put it into `scene`:
+
 ```py
-scene.set_light_dir([1, 2, -2])
+camera = t3.Camera()
+scene.add_camera(camera)
+``` 
+
+NOTE: camera creations should also be put as forward as possible.
+
+---
+
+Also don't forget to set the light:
+```py
+light = t3.Light()
+scene.add_light(light)
 ```
 
 ---
@@ -87,7 +107,7 @@ Finally, create a GUI. And here goes the main loop:
 gui = ti.GUI('Monkey')
 while gui.running:
     scene.render()            # render the model(s) into image
-    gui.set_image(scene.img)  # display the result image
+    gui.set_image(camera.img)  # display the result image
     gui.show()
 ```
 

--- a/examples/ball_simulation.py
+++ b/examples/ball_simulation.py
@@ -19,7 +19,6 @@ radius = ti.var(ti.f32, N)
 
 model.particles = pos
 
-scene.set_light_dir([1, 1, -1])
 
 @ti.kernel
 def init():

--- a/examples/binding_textures.py
+++ b/examples/binding_textures.py
@@ -11,7 +11,8 @@ camera = t3.Camera()
 scene.add_model(model)
 scene.add_camera(camera)
 
-scene.set_light_dir([0.4, -1.5, 1.8])
+light = t3.Light([0.4, -1.5, 1.8])
+scene.add_light(light)
 gui = ti.GUI('Model', camera.res)
 while gui.running:
     gui.get_event(None)

--- a/examples/loading_model.py
+++ b/examples/loading_model.py
@@ -10,7 +10,8 @@ scene.add_model(model)
 camera = t3.Camera()
 scene.add_camera(camera)
 
-scene.set_light_dir([0.4, -1.5, 1.8])
+light = t3.Light([0.4, -1.5, 1.8])
+scene.add_light(light)
 gui = ti.GUI('Model', camera.res)
 while gui.running:
     gui.get_event(None)

--- a/examples/ms_cloth.py
+++ b/examples/ms_cloth.py
@@ -3,7 +3,7 @@ import taichi_glsl as tl
 import taichi_three as t3
 import numpy as np
 
-ti.init(ti.opengl)
+ti.init(ti.cuda)
 
 ### Parameters
 
@@ -59,6 +59,8 @@ scene.add_model(model)
 camera = t3.Camera()
 scene.add_camera(camera)
 camera.type = camera.ORTHO
+light = t3.Light([0.4, -1.5, 1.8])
+scene.add_light(light)
 
 
 @ti.kernel
@@ -89,7 +91,6 @@ def update_display():
 
 init()
 init_display()
-scene.set_light_dir([0.4, -1.5, 1.8])
 
 with ti.GUI('Mass Spring') as gui:
     while gui.running and not gui.get_event(gui.ESCAPE):

--- a/examples/multicamera.py
+++ b/examples/multicamera.py
@@ -8,21 +8,22 @@ scene = t3.Scene()
 texture = ti.imread("assets/cloth.jpg")
 model = t3.Model(obj=t3.readobj('assets/monkey.obj', scale=0.8), tex=texture)
 scene.add_model(model)
-camera = t3.Camera(res=(256, 256))
+camera = t3.Camera(res=(256, 256), pos=[0, 0, 2.5], target=[0, 0, 0], up=[0, 1, 0])
 scene.add_camera(camera)
 
-camera2 = t3.Camera()
+camera2 = t3.Camera(pos=[0, 1, -2], target=[0, 1, 0], up=[0, 1, 0])
 scene.add_camera(camera2)
 
+light = t3.Light([0.4, -1.5, -0.8])
+scene.add_light(light)
+
 camera.type = camera.ORTHO
-camera.set(pos=[0, 0, 2.5], target=[0, 0, 0], up=[0, 1, 0])
-camera2.set(pos=[0, 1, -2], target=[0, 1, 0], up=[0, 1, 0])
 camera2.set_intrinsic(256, 256, 256, 256)
 
 print(camera2.export_intrinsic())
 print(camera2.export_extrinsic())
 
-scene.set_light_dir([0.4, -1.5, -0.8])
+
 gui = ti.GUI('Model', camera.res)
 gui2 = ti.GUI('Model2', camera2.res)
 

--- a/examples/multilight.py
+++ b/examples/multilight.py
@@ -1,0 +1,24 @@
+import taichi as ti
+import taichi_three as t3
+import numpy as np
+
+ti.init(ti.cpu)
+
+scene = t3.Scene()
+texture = ti.imread("assets/cloth.jpg")
+model = t3.Model(obj=t3.readobj('assets/torus.obj', scale=0.6), tex=texture)
+scene.add_model(model)
+camera = t3.Camera(res=(512, 512), pos=[0, 2, -4], target=[0, 2, 0])
+scene.add_camera(camera)
+
+light = t3.Light(dir=[0, 0, 1], color=[1.0, 1.0, 1.0])
+scene.add_light(light)
+light2 = t3.Light(dir=[0, -1, 0], color=[1.0, 1.0, 1.0])
+scene.add_light(light2)
+gui = ti.GUI('Model', camera.res)
+while gui.running:
+    gui.running = not gui.get_event(ti.GUI.ESCAPE)
+    camera.from_mouse(gui)
+    scene.render()
+    gui.set_image(camera.img)
+    gui.show()

--- a/examples/multilight.py
+++ b/examples/multilight.py
@@ -6,15 +6,16 @@ ti.init(ti.cpu)
 
 scene = t3.Scene()
 texture = ti.imread("assets/cloth.jpg")
-model = t3.Model(obj=t3.readobj('assets/torus.obj', scale=0.6), tex=texture)
+model = t3.Model(obj=t3.readobj('assets/monkey.obj', scale=0.6), tex=texture)
 scene.add_model(model)
-camera = t3.Camera(res=(512, 512), pos=[0, 2, -4], target=[0, 2, 0])
+camera = t3.Camera(res=(512, 512), pos=[0, 0, -2], target=[0, 0, 0])
 scene.add_camera(camera)
 
 light = t3.Light(dir=[0, 0, 1], color=[1.0, 1.0, 1.0])
 scene.add_light(light)
 light2 = t3.Light(dir=[0, -1, 0], color=[1.0, 1.0, 1.0])
 scene.add_light(light2)
+
 gui = ti.GUI('Model', camera.res)
 while gui.running:
     gui.running = not gui.get_event(ti.GUI.ESCAPE)

--- a/examples/simple_triangle.py
+++ b/examples/simple_triangle.py
@@ -11,11 +11,13 @@ scene.add_model(model)
 camera = t3.Camera()
 scene.add_camera(camera)
 
+light = t3.Light([0.4, -1.5, 1.8])
+scene.add_light(light)
+
 model.vi.from_numpy(np.array(
     [[+0.0, +0.5, 0.0], [-0.5, -0.5, 0.0], [+0.5, -0.5, 0.0]]))
 model.faces.from_numpy(np.array([[0, 1, 2], [0, 2, 1]])) # both cull faces
 
-scene.set_light_dir([0.4, -1.5, 1.8])
 gui = ti.GUI('Triangle', camera.res)
 while gui.running:
     gui.get_event(None)

--- a/examples/transform_models.py
+++ b/examples/transform_models.py
@@ -15,7 +15,8 @@ camera = t3.Camera()
 camera.type = camera.ORTHO
 scene.add_camera(camera)
 
-scene.set_light_dir([0.4, -1.5, 1.8])
+light = t3.Light([0.4, -1.5, 1.8])
+scene.add_light(light)
 gui = ti.GUI('Transform', camera.res)
 while gui.running:
     gui.get_event(None)

--- a/taichi_three/__init__.py
+++ b/taichi_three/__init__.py
@@ -8,3 +8,4 @@ from .geometry import *
 from .loader import *
 from .raycast import *
 from .meshgen import *
+from .light import *

--- a/taichi_three/geometry.py
+++ b/taichi_three/geometry.py
@@ -25,7 +25,7 @@ def render_triangle(model, camera, face):
         # shading
         color = ts.vec3(0.0)
         for light in ti.static(scene.lights):
-            light_color = scene.opt.render_func(pos, normal, ts.vec3(0.0), light)
+            color += scene.opt.render_func(pos, normal, ts.vec3(0.0), light)
         color = scene.opt.pre_process(color)
         A = camera.uncook(a)
         B = camera.uncook(b)

--- a/taichi_three/geometry.py
+++ b/taichi_three/geometry.py
@@ -25,9 +25,7 @@ def render_triangle(model, camera, face):
         # shading
         color = ts.vec3(0.0)
         for light in ti.static(scene.lights):
-            light_dir = camera.untrans_dir(light.dir[None])
-            light_color = scene.opt.render_func(pos, normal, ts.vec3(0.0), light_dir, camera)
-            color += light_color * light.color[None]
+            light_color = scene.opt.render_func(pos, normal, ts.vec3(0.0), light)
         color = scene.opt.pre_process(color)
         A = camera.uncook(a)
         B = camera.uncook(b)

--- a/taichi_three/geometry.py
+++ b/taichi_three/geometry.py
@@ -23,8 +23,11 @@ def render_triangle(model, camera, face):
     pos = (a + b + c) / 3
     if ts.dot(pos, normal) <= 0:
         # shading
-        light_dir = camera.untrans_dir(scene.light_dir[None])
-        color = scene.opt.render_func(pos, normal, ts.vec3(0.0), light_dir)
+        color = ts.vec3(0.0)
+        for light in ti.static(scene.lights):
+            light_dir = camera.untrans_dir(light.dir[None])
+            light_color = scene.opt.render_func(pos, normal, ts.vec3(0.0), light_dir, camera)
+            color += light_color * light.color[None]
         color = scene.opt.pre_process(color)
         A = camera.uncook(a)
         B = camera.uncook(b)

--- a/taichi_three/light.py
+++ b/taichi_three/light.py
@@ -9,12 +9,12 @@ The base light class represents a directional light.
 @ti.data_oriented
 class Light(AutoInit):
 
-    def __init__(self, direction=None, color=None):
-        direction = direction or [0, 0, 1]
-        norm = math.sqrt(sum(x ** 2 for x in direction))
-        direction = [x / norm for x in direction]
+    def __init__(self, dir=None, color=None):
+        dir = dir or [0, 0, 1]
+        norm = math.sqrt(sum(x ** 2 for x in dir))
+        dir = [x / norm for x in dir]
  
-        self.dir_py = [-x for x in direction]
+        self.dir_py = [-x for x in dir]
         self.color_py = color or [1, 1, 1] 
 
         self.dir = ti.Vector(3, ti.float32, ())
@@ -23,10 +23,10 @@ class Light(AutoInit):
         # so that we don't have to compute it for each vertex
         self.viewdir = ti.Vector(3, ti.float32, ())
 
-    def set(self, direction=[0, 0, 1], color=[1, 1, 1]):
-        norm = math.sqrt(sum(x**2 for x in direction))
-        direction = [x / norm for x in direction]
-        self.dir_py = direction
+    def set(self, dir=[0, 0, 1], color=[1, 1, 1]):
+        norm = math.sqrt(sum(x**2 for x in dir))
+        dir = [x / norm for x in dir]
+        self.dir_py = dir
         self.color = color
 
     def _init(self):

--- a/taichi_three/light.py
+++ b/taichi_three/light.py
@@ -3,28 +3,54 @@ import taichi_glsl as ts
 from .common import *
 import math
 
+'''
+The base light class represents a directional light.
+'''
 @ti.data_oriented
 class Light(AutoInit):
 
-    def __init__(self, dir=None, color=None):
-        dir = dir or [0, 0, 1]
-        norm = math.sqrt(sum(x ** 2 for x in dir))
-        dir = [x / norm for x in dir]
-
-        self.np_dir = [-x for x in dir]
-        self.np_color = color or [1, 1, 1]
+    def __init__(self, direction=None, color=None):
+        direction = direction or [0, 0, 1]
+        norm = math.sqrt(sum(x ** 2 for x in direction))
+        direction = [x / norm for x in direction]
+ 
+        self.dir_py = [-x for x in direction]
+        self.color_py = color or [1, 1, 1] 
 
         self.dir = ti.Vector(3, ti.float32, ())
         self.color = ti.Vector(3, ti.float32, ())
+        # store the current light direction in the view space
+        # so that we don't have to compute it for each vertex
+        self.viewdir = ti.Vector(3, ti.float32, ())
 
-    def set(self, dir=[0, 0, 1], color=[1, 1, 1]):
-        norm = math.sqrt(sum(x**2 for x in dir))
-        dir = [x / norm for x in dir]
-        self.np_dir = dir
+    def set(self, direction=[0, 0, 1], color=[1, 1, 1]):
+        norm = math.sqrt(sum(x**2 for x in direction))
+        direction = [x / norm for x in direction]
+        self.dir_py = direction
         self.color = color
 
     def _init(self):
+        self.dir[None] = self.dir_py
+        self.color[None] = self.color_py
 
-        
-        self.dir[None] = self.np_dir
-        self.color[None] = self.np_color
+    @ti.func
+    def intensity(self, pos):
+        return 1
+
+    @ti.func
+    def get_color(self, pos):
+        return self.color[None] * self.intensity(pos)
+
+    @ti.func
+    def get_dir(self, pos):
+        return self.viewdir
+
+    @ti.func
+    def set_view(self, camera):
+        self.viewdir[None] = camera.untrans_dir(self.dir[None])
+
+
+
+class PointLight(Light):
+    pass
+

--- a/taichi_three/light.py
+++ b/taichi_three/light.py
@@ -1,0 +1,30 @@
+import taichi as ti
+import taichi_glsl as ts
+from .common import *
+import math
+
+@ti.data_oriented
+class Light(AutoInit):
+
+    def __init__(self, dir=None, color=None):
+        dir = dir or [0, 0, 1]
+        norm = math.sqrt(sum(x ** 2 for x in dir))
+        dir = [x / norm for x in dir]
+
+        self.np_dir = [-x for x in dir]
+        self.np_color = color or [1, 1, 1]
+
+        self.dir = ti.Vector(3, ti.float32, ())
+        self.color = ti.Vector(3, ti.float32, ())
+
+    def set(self, dir=[0, 0, 1], color=[1, 1, 1]):
+        norm = math.sqrt(sum(x**2 for x in dir))
+        dir = [x / norm for x in dir]
+        self.np_dir = dir
+        self.color = color
+
+    def _init(self):
+
+        
+        self.dir[None] = self.np_dir
+        self.color[None] = self.np_color

--- a/taichi_three/scene.py
+++ b/taichi_three/scene.py
@@ -21,7 +21,7 @@ class Scene(AutoInit):
             light = Light(ldir)
             self.add_light(light)
         else:
-            self.light[0].set(dir=ldir)
+            self.light[0].set(ldir)
 
     @ti.func
     def cook_coor(self, I, camera):
@@ -64,6 +64,9 @@ class Scene(AutoInit):
         if ti.static(len(self.cameras)):
             for camera in ti.static(self.cameras):
                 camera.clear_buffer()
+                # sets up light directions
+                for light in ti.static(self.lights):
+                    light.set_view(camera)
                 if ti.static(len(self.models)):
                     for model in ti.static(self.models):
                         model.render(camera)

--- a/taichi_three/scene.py
+++ b/taichi_three/scene.py
@@ -2,12 +2,13 @@ import taichi as ti
 import taichi_glsl as ts
 from .transform import *
 from .shading import *
+from .light import *
 
 
 @ti.data_oriented
 class Scene(AutoInit):
     def __init__(self):
-        self.light_dir = ti.Vector.var(3, ti.f32, ())
+        self.lights = []
         self.cameras = []
         self.opt = Shading()
         self.models = []
@@ -16,9 +17,11 @@ class Scene(AutoInit):
         # changes light direction input to the direction
         # from the light towards the object
         # to be consistent with future light types
-        norm = math.sqrt(sum(x**2 for x in ldir))
-        ldir = [-x / norm for x in ldir]
-        self.light_dir[None] = ldir
+        if not self.lights:
+            light = Light(ldir)
+            self.add_light(light)
+        else:
+            self.light[0].set(dir=ldir)
 
     @ti.func
     def cook_coor(self, I, camera):
@@ -40,7 +43,13 @@ class Scene(AutoInit):
         camera.scene = self
         self.cameras.append(camera)
 
+    def add_light(self, light):
+        light.scene = self
+        self.lights.append(light)
+
     def _init(self):
+        for light in self.lights:
+            light.init()
         for camera in self.cameras:
             camera.init()
         for model in self.models:

--- a/taichi_three/shading.py
+++ b/taichi_three/shading.py
@@ -1,5 +1,6 @@
 import taichi as ti
 import taichi_glsl as ts
+from .transform import *
 import math
 
 class Shading:
@@ -15,7 +16,6 @@ class Shading:
     @ti.func
     def render_func(self, pos, normal, dir, light_dir):
         color = ts.vec3(0.0)
-
         shineness = self.shineness
         half_lambert = ts.dot(normal, light_dir) * 0.5 + 0.5
         lambert = max(0, ts.dot(normal, light_dir))
@@ -38,7 +38,6 @@ class Shading:
 
         if ti.static(self.is_normal_map):
             color = normal * 0.5 + 0.5
-
         return color
 
     @ti.func

--- a/taichi_three/shading.py
+++ b/taichi_three/shading.py
@@ -14,8 +14,9 @@ class Shading:
         self.__dict__.update(kwargs)
 
     @ti.func
-    def render_func(self, pos, normal, dir, light_dir):
+    def render_func(self, pos, normal, dir, light):
         color = ts.vec3(0.0)
+        light_dir = light.get_dir(pos)
         shineness = self.shineness
         half_lambert = ts.dot(normal, light_dir) * 0.5 + 0.5
         lambert = max(0, ts.dot(normal, light_dir))
@@ -38,7 +39,7 @@ class Shading:
 
         if ti.static(self.is_normal_map):
             color = normal * 0.5 + 0.5
-        return color
+        return color * light.get_color(pos)
 
     @ti.func
     def pre_process(self, color):

--- a/taichi_three/transform.py
+++ b/taichi_three/transform.py
@@ -112,7 +112,7 @@ class Camera(AutoInit):
         self.pos = ti.Vector(3, ti.f32, ())
         self.target = ti.Vector(3, ti.f32, ())
         self.intrinsic = ti.Matrix(3, 3, ti.f32, ())
-        self.type = self.COS_FOV
+        self.type = self.TAN_FOV
         self.fov = math.radians(fov)
 
         self.cx = cx or self.res[0] // 2

--- a/taichi_three/transform.py
+++ b/taichi_three/transform.py
@@ -288,7 +288,7 @@ class Camera(AutoInit):
             pos[1] *= self.intrinsic[None][1, 1]
             pos[0] += self.intrinsic[None][0, 2]
             pos[1] += self.intrinsic[None][1, 2]
-        elif ti.static(self.type == ti.TAN_FOV):
+        elif ti.static(self.type == self.TAN_FOV):
             pos = self.intrinsic[None] @ pos
             pos[0] /= abs(pos[2])
             pos[1] /= abs(pos[2])

--- a/taichi_three/transform.py
+++ b/taichi_three/transform.py
@@ -129,7 +129,7 @@ class Camera(AutoInit):
         self.mpos = (0, 0)
 
     def set_intrinsic(self, fx=None, fy=None, cx=None, cy=None):
-        # see http://ais.informatik.uni-freiburg.de/teaching/ws09/robotics2/pdfs/rob2-08-camera-calibration.pdf, 
+        # see http://ais.informatik.uni-freiburg.de/teaching/ws09/robotics2/pdfs/rob2-08-camera-calibration.pdf
         self.fx = fx or self.fx
         self.fy = fy or self.fy
         self.cx = cx or self.cx

--- a/taichi_three/transform.py
+++ b/taichi_three/transform.py
@@ -104,7 +104,7 @@ class Camera(AutoInit):
     COS_FOV = 'Cosine Perspective' # curvilinear perspective, see en.wikipedia.org/wiki/Curvilinear_perspective
 
     def __init__(self, res=None, fx=None, fy=None, cx=None, cy=None,
-            pos=[0, 0, -2], target=[0, 0, 0], up=[0, 1, 0], fov=45):
+            pos=[0, 0, -2], target=[0, 0, 0], up=[0, 1, 0], fov=30):
         self.res = res or (512, 512)
         self.img = ti.Vector.var(3, ti.f32, self.res)
         self.zbuf = ti.var(ti.f32, self.res)


### PR DESCRIPTION
Three minor fixes:
1. The (rectilinear/tangent) field of view was added to the camera projection matrix. Also gives a hint that the curvilinear perspective has not been implemented for rasterized rendering.
2. When a fragment is behind the camera plane (*z* < 0), its projected X and Y coordinates were not inverted to produce the correct image when some of the vertices in a triangle are behind the camera.
3. Adjusted the camera control as discussed in #9. The target should *only be changed when pressing CTRL* in orbiting and zooming movements. This allows users to orbit the target in a closer details when zoomed in.

