### PR TITLE
Let there be light

### DIFF
--- a/examples/ball_simulation.py
+++ b/examples/ball_simulation.py
@@ -12,6 +12,8 @@ scene.add_model(model)
 camera = t3.Camera()
 scene.add_camera(camera)
 #camera.type = camera.ORTHO
+light = t3.Light()
+scene.add_light(light)
 
 pos = ti.Vector.field(3, ti.f32, N)
 vel = ti.Vector.field(3, ti.f32, N)


### PR DESCRIPTION
The ball simulation example doesn't include lights in the scene, causing following error. This PR is intended to fix this.

```
[Taichi] mode=release
[Taichi] preparing sandbox at /var/folders/59/8w1k63jj0vs_rv19jwyf1nf00000gn/T/taichi-cuy0r964
[Taichi] version 0.6.30, llvm 10.0.0, commit 6937b1e2, osx, python 3.8.5
[TaiGLSL] version 0.0.9
[TaiGLSL] Inputs are welcomed at https://github.com/taichi-dev/taichi_glsl
[Tai3D] version 0.0.3
[Taichi] Starting on arch=x64
[Taichi] materializing...
Traceback (most recent call last):
  File "examples/ball_simulation.py", line 71, in <module>
    scene.render()
  File "/usr/local/lib/python3.8/site-packages/taichi_three-0.0.3-py3.8.egg/taichi_three/scene.py", line 60, in render
    self._render()
  File "/usr/local/lib/python3.8/site-packages/taichi/lang/kernel.py", line 603, in __call__
    return self._primal(self._kernel_owner, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/taichi/lang/kernel.py", line 499, in __call__
    self.materialize(key=key, args=args, arg_features=arg_features)
  File "/usr/local/lib/python3.8/site-packages/taichi/lang/kernel.py", line 370, in materialize
    taichi_kernel = taichi_kernel.define(taichi_ast_generator)
  File "/usr/local/lib/python3.8/site-packages/taichi/lang/kernel.py", line 367, in taichi_ast_generator
    compiled()
  File "/usr/local/lib/python3.8/site-packages/taichi_three-0.0.3-py3.8.egg/taichi_three/scene.py", line 68, in _render
    for light in ti.static(self.lights):
UnboundLocalError: local variable 'light' referenced before assignment
```